### PR TITLE
Update club description div for text wrapping.

### DIFF
--- a/src/routes/(main)/clubs/[id]/+page.svelte
+++ b/src/routes/(main)/clubs/[id]/+page.svelte
@@ -439,7 +439,7 @@
               <div class="text-base-content/50 mb-1 text-xs tracking-wide uppercase">
                 {m.club_introduction()}
               </div>
-              <div class="text-sm leading-relaxed">
+              <div class="text-sm leading-relaxed break-all">
                 {data.club.description}
               </div>
             </div>


### PR DESCRIPTION
强制从中间换行，防止长url超出显示区域

修复前
<img width="1844" height="1088" alt="image" src="https://github.com/user-attachments/assets/8d2e65b7-c63b-428f-91df-b5e503507d25" />

修复后
<img width="2004" height="1074" alt="image" src="https://github.com/user-attachments/assets/b701a910-c4c5-431e-b466-247c269aae0b" />
